### PR TITLE
Use CGI.unescapeHTML on FormAnswer#document fields

### DIFF
--- a/app/models/reports/admin/assessor_judge_admin_data_report.rb
+++ b/app/models/reports/admin/assessor_judge_admin_data_report.rb
@@ -56,7 +56,7 @@ class Reports::Admin::AssessorJudgeAdminDataReport
         u = Reports::User.new(user)
 
         csv << mapping.map do |m|
-          Utils::String.sanitize(
+          unescape_and_sanitize(
             u.call_method(m[:method]),
           )
         end
@@ -66,7 +66,7 @@ class Reports::Admin::AssessorJudgeAdminDataReport
         u = Reports::User.new(user)
 
         csv << mapping.map do |m|
-          Utils::String.sanitize(
+          unescape_and_sanitize(
             u.call_method(m[:method]),
           )
         end
@@ -76,7 +76,7 @@ class Reports::Admin::AssessorJudgeAdminDataReport
         u = Reports::User.new(user)
 
         csv << mapping.map do |m|
-          Utils::String.sanitize(
+          unescape_and_sanitize(
             u.call_method(m[:method]),
           )
         end

--- a/app/models/reports/csv_helper.rb
+++ b/app/models/reports/csv_helper.rb
@@ -9,9 +9,7 @@ module Reports::CsvHelper
         form_answer = Reports::FormAnswer.new(form_answer)
 
         csv << mapping.map do |m|
-          Utils::String.sanitize(
-            form_answer.call_method(m[:method]),
-          )
+          unescape_and_sanitize(form_answer.call_method(m[:method]))
         end
       end
     end
@@ -29,8 +27,7 @@ module Reports::CsvHelper
         end
 
         csv << mapping.map do |m|
-          raw = f.call_method(m[:method])
-          Utils::String.sanitize(raw)
+          unescape_and_sanitize(f.call_method(m[:method]))
         end
       end
     end
@@ -44,8 +41,7 @@ module Reports::CsvHelper
         f = Reports::FormAnswer.new(fa, limited_access)
 
         row = mapping.map do |m|
-          raw = f.call_method(m[:method])
-          Utils::String.sanitize(raw)
+          unescape_and_sanitize(f.call_method(m[:method]))
         end
 
         yielder << CSV.generate_line(row, encoding: "UTF-8", force_quotes: true)
@@ -54,6 +50,14 @@ module Reports::CsvHelper
   end
 
   private
+
+  def unescape_and_sanitize(string)
+    CGI.unescapeHTML(
+      Utils::String.sanitize(
+        string,
+      ),
+    )
+  end
 
   def find_each_with_order(scope, batch_size: 100, &block)
     ordered_ids = scope.pluck(:id)

--- a/app/models/reports/reception_buckingham_palace_report.rb
+++ b/app/models/reports/reception_buckingham_palace_report.rb
@@ -97,7 +97,7 @@ class Reports::ReceptionBuckinghamPalaceReport
 
         row = mapping.map do |m|
           raw = attendee_pointer.call_method(m[:method])
-          Utils::String.sanitize(raw)
+          unescape_and_sanitize(raw)
         end
 
         yielder << CSV.generate_line(row, encoding: "UTF-8", force_quotes: true)

--- a/spec/models/reports/all_entries_spec.rb
+++ b/spec/models/reports/all_entries_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+describe Reports::AllEntries do
+  let(:year) { create(:award_year) }
+  let(:report) { described_class.new(year) }
+
+  describe "#stream" do
+    let(:result) { report.stream.to_a }
+
+    context "with a form_answer that has a document with escaped characters" do
+      let(:form_answer) { create(:form_answer, :innovation, :recommended, award_year: year) }
+      let(:escaped_character) { "&amp;" }
+
+      before do
+        form_answer.document["innovation_desc_short"] = "<p>AI powered platform that identifies (and completes) optimisation opportunities on business websites quickly #{escaped_character} easily.</p>\r\n"
+        form_answer.save!
+      end
+
+      it "does escape the characters" do
+        expect(result.length).to eq(2)
+        expect(result.second).to include("AI powered platform that identifies (and completes) optimisation opportunities on business websites quickly & easily.")
+        expect(result.second).not_to include(escaped_character)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, escaped values in the FormAnswer#document are rendering in csv reports. This PR solves the problem by unescaping them in the `Reports::CsvHelper`

[Asana](https://app.asana.com/1/18526863193321/project/1200504523179343/task/1209573913904575)