### PR TITLE
Use correct keys when admin views or edits a PO/mobility form answer

### DIFF
--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -411,7 +411,7 @@ class FormAnswerDecorator < ApplicationDecorator
   end
 
   def mobility_desc_short
-    sanitize_html document["mobility_desc_short"]
+    sanitize_html document[goods_and_services_key]
   end
 
   def one_line_description_of_interventions
@@ -423,7 +423,13 @@ class FormAnswerDecorator < ApplicationDecorator
     when "innovation"
       "innovation_desc_short"
     when "mobility"
-      "mobility_desc_short"
+      if award_year.year <= 2020
+        "mobility_desc_short"
+      elsif award_year.year <= 2023
+        (document["application_category"] == "initiative") ? "initiative_desc_short" : "organisation_desc_short"
+      else
+        "initiative_desc_short"
+      end
     when "development"
       if award_year.year >= 2020
         "one_line_description_of_interventions"

--- a/spec/decorators/form_answer_decorator_spec.rb
+++ b/spec/decorators/form_answer_decorator_spec.rb
@@ -33,7 +33,7 @@ DOCUMENT_FIELDS = {
   innovation_desc_short: "innovation_desc_short",
   development_desc_short: "development_desc_short",
   development_management_approach_briefly: "development_management_approach_briefly",
-  mobility_desc_short: "mobility_desc_short",
+  mobility_desc_short: "initiative_desc_short",
   organisation_type: "organisation_type",
 }
 
@@ -192,7 +192,7 @@ describe FormAnswerDecorator do
     describe "##{field}" do
       it "returns the document field with key #{DOCUMENT_FIELDS[field]}" do
         document = { DOCUMENT_FIELDS[field] => "An expected value" }
-        form = build(:form_answer, :development, document: document)
+        form = build(:form_answer, (field == :mobility_desc_short) ? :mobility : :development, document: document)
 
         decorated_app = described_class.new(form)
         expect(decorated_app.send(field)).to eq(document[DOCUMENT_FIELDS[field]])


### PR DESCRIPTION
From the looks of `Reports::DataPickers::FormDocumentPicker` line 295-301 it seems like this key changes depending on the year that the form was submitted. I've done some checks in prod console and they seem to check out.

Tests needed some modification so the methods would produce the expected value.