### PR TITLE
Silence ActiveRecord::Base.default_timezone deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem "kaminari"
 gem "wicked", "~> 1.1"
 
 # Statemachine
-gem "statesman", "3.5.0"
+gem "statesman", "9.0.1"
 
 # Form & Data helpers
 gem "simple_form", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -644,7 +644,7 @@ GEM
     standard-performance (1.3.1)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.20.2)
-    statesman (3.5.0)
+    statesman (9.0.1)
     temple (0.8.2)
     thor (1.3.1)
     thread_safe (0.3.6)
@@ -803,7 +803,7 @@ DEPENDENCIES
   sprockets-rails (>= 2.0.0)
   stackprof
   standard
-  statesman (= 3.5.0)
+  statesman (= 9.0.1)
   timecop
   turnip (~> 4.2.0)
   uglifier (>= 2.7.2)

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -9,7 +9,6 @@ require_relative "../../forms/award_years/v2025/qae_forms"
 require_relative "../../forms/award_years/v2026/qae_forms"
 
 class FormAnswer < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordQueries
   include PgSearch::Model
   extend Enumerize
   include FormAnswerStatesHelper
@@ -522,6 +521,8 @@ class FormAnswer < ApplicationRecord
   def self.initial_state
     FormAnswerStateMachine.initial_state
   end
+
+  include Statesman::Adapters::ActiveRecordQueries
 
   private
 


### PR DESCRIPTION
Updates the version of the `statesman` gem. The current version is calling the deprecated `ActiveRecord::Base.default_timezone` so logging multiple multiple warnings:

<img width="884" alt="image" src="https://github.com/user-attachments/assets/229446b4-4618-4af4-a899-5a8d85ccc57c" />