### PR TITLE
fix: makes eligibility radio buttons inline

### DIFF
--- a/app/views/form_award_eligibilities/questions/_promoting_opportunity_involvement.html.slim
+++ b/app/views/form_award_eligibilities/questions/_promoting_opportunity_involvement.html.slim
@@ -1,3 +1,6 @@
+style
+  | span.radio.govuk-radios__item { flex-wrap: nowrap !important; }
+
 .question-body
   p.govuk-body
     | Social mobility is a measure of the ability to move from a lower socio-economic background to higher socio-economic status.


### PR DESCRIPTION
Where radio buttons have long labels these were wrapping onto a new line due to `flex-wrap: wrap` on the wrapper. This was happening on an eligbility question in Promoting Opportunity with long labels. The behaviour we wanted is for the labels to remain on the same line as the radio input.

Simple form config is used to create wrappers and apply classes and it did not seem possible to directly add styles to the wrapper (using input_wrapper_html for example). Therefore a style is applied to this view to only apply to this question.

<img width="855" alt="Screenshot 2025-04-05 at 10 53 31" src="https://github.com/user-attachments/assets/6b19ff11-9dd4-436d-9615-15376ccd1746" />