### PR TITLE
fix: fix logic for displaying incorrect message in winners stage

### DIFF
--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -190,6 +190,7 @@ class FormAnswer < ApplicationRecord
   scope :require_vocf, -> { where(award_type: %w[trade innovation]) }
   scope :vocf_free, -> { where(award_type: %w[mobility development]) }
   scope :provided_estimates, -> { where("document #>> '{product_estimated_figures}' = 'yes'") }
+  scope :have_award_decision, -> { where(state: ["awarded", "not_awarded"]) }
 
   # callbacks
   before_save :set_award_year, unless: :award_year

--- a/app/views/content_only/dashboard.html.slim
+++ b/app/views/content_only/dashboard.html.slim
@@ -2,10 +2,10 @@
 
 - provide(:page_wrapper_class, "page-dashboard")
 
-- if Settings.after_shortlisting_stage?
-  = render "content_only/info_messages/award_season_shortlisting"
-- elsif Settings.winners_stage?
+- if Settings.winners_stage?
   = render "content_only/info_messages/award_season_closed"
+- elsif Settings.after_shortlisting_stage?
+  = render "content_only/info_messages/award_season_shortlisting"
 - elsif submission_started?
   = render "content_only/info_messages/award_season_open"
 - elsif Settings.current_award_year_switched?

--- a/app/views/content_only/dashboard.html.slim
+++ b/app/views/content_only/dashboard.html.slim
@@ -6,7 +6,7 @@
   = render "content_only/info_messages/award_season_closed"
 - elsif Settings.after_shortlisting_stage?
   = render "content_only/info_messages/award_season_shortlisting"
-- elsif submission_started?
+- elsif submission_started? && !submission_ended?
   = render "content_only/info_messages/award_season_open"
 - elsif Settings.current_award_year_switched?
   = render "content_only/info_messages/award_season_closed"

--- a/app/views/content_only/info_messages/_award_season_closed.html.slim
+++ b/app/views/content_only/info_messages/_award_season_closed.html.slim
@@ -4,6 +4,19 @@ div[class="govuk-notification-banner" role="region" aria-labelledby="govuk-notif
       ' Important
   div[class="govuk-notification-banner__content"]
     = render "content_only/info_messages/new_users_message"
+
+    - if Settings.winners_stage? && @current_user.form_answers.have_award_decision.for_year(AwardYear.current.year).any?
+      h3[class="govuk-notification-banner__heading" style="max-width: 100%;"]
+        ' Your Current Application
+      p[class="govuk-body" style="max-width: 100%;"]
+        ' You should have received an email from us notifying you of the outcome of your application.
+      p[class="govuk-body" style="max-width: 100%;"]
+        ' Please check your spam/junk mail if you haven’t heard and then contact us using the helpline or email below.
+      p[class="govuk-body" style="max-width: 100%;"]
+        = link_to "kingsawards@businessandtrade.gov.uk", "mailto: kingsawards@businessandtrade.gov.uk", class: 'govuk-link'
+        br
+        ' 020 4551 0081
+
     h3[class="govuk-notification-banner__heading" style="max-width: 100%;"]
       ' Next round of Awards
     p[class="govuk-body" style="max-width: 100%;"]


### PR DESCRIPTION
- fixes logic for displaying winners info banner. This must be the first condition as its the final stage of the awards season
- adds a new banner message for users who have an application that was either award or not awarded 

https://app.asana.com/1/18526863193321/project/1200504523179343/task/1209936775438031?focus=true

<img width="1073" alt="Screenshot 2025-04-09 at 15 19 09" src="https://github.com/user-attachments/assets/fb8d6bdb-8be6-495c-b755-9bd1d681060a" />
