### PR TITLE
Revise storage locations

### DIFF
--- a/app/models/concerns/scan_files.rb
+++ b/app/models/concerns/scan_files.rb
@@ -50,7 +50,7 @@ module ScanFiles
     clean_bucket_s3_client.put_object(
       bucket: ENV["AWS_S3_PERMANENT_BUCKET"],
       body: object_to_copy.body.read,
-      key: file.permanent_path,
+      key: file.path,
     )
 
     tmp_bucket_s3_client.delete_object(

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -5,7 +5,7 @@ class FileUploader < CarrierWave::Uploader::Base
   storage :custom
 
   def store_dir
-    "uploads/#{base_dir}/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
   def read
@@ -28,15 +28,11 @@ class FileUploader < CarrierWave::Uploader::Base
     clean? ? ENV["AWS_S3_PERMANENT_BUCKET"] : ENV["AWS_S3_TMP_BUCKET"]
   end
 
-  def permanent_path
+  def permanent_path # only for local file usage
     path.sub("tmp", "permanent")
   end
 
   private
-
-  def base_dir
-    clean? ? "permanent" : "tmp"
-  end
 
   def clean?
     model.respond_to?(:clean?) && model.clean?

--- a/app/uploaders/form_answer_pdf_version_uploader.rb
+++ b/app/uploaders/form_answer_pdf_version_uploader.rb
@@ -5,6 +5,32 @@ class FormAnswerPdfVersionUploader < CarrierWave::Uploader::Base
     end
   end
 
+  def read
+    if Rails.env.production? || ENV["ENABLE_VIRUS_SCANNER_BUCKETS"] == "true"
+      permanent_file = CarrierWave::Storage::Fog::File.new(self, permanent_storage, store_path)
+      permanent_file.read
+    else
+      File.read(path)
+    end
+  end
+
+  def permanent_storage
+    @permanent_storage ||= CarrierWave::Storage::Fog.new(self)
+  end
+
+  def fog_directory
+    ENV["AWS_S3_PERMANENT_BUCKET"]
+  end
+
+  def fog_credentials
+    {
+      provider: "AWS",
+      aws_access_key_id: ENV["AWS_PERMANENT_BUCKET_ACCESS_KEY_ID"],
+      aws_secret_access_key: ENV["AWS_PERMANENT_BUCKET_SECRET_ACCESS_KEY"],
+      region: ENV["AWS_REGION"],
+    }
+  end
+
   def extension_allowlist
     %w[pdf]
   end


### PR DESCRIPTION
Use permanent (clean) bucket for files that do not need scanning:
The only Uploader that does not involve scanning seems to be the `form_answer_pdf_version_uploader`.
Here we set the fog_directory and fog_credentials for reading/writing these files, since we should not use the Carrierwave default of the tmp bucket in this case. The filepath already did not contain /tmp or /permanent, so we're good there.
Note: Since files will have been uploaded to the tmp bucket due to the current code, these (~750 of them) will need to be moved to the clean bucket. 

Stop using /tmp and /permanent in the paths for files stored in buckets. This is to make the system compatible with files uploaded pre-scanner work. IMO these isn't a need to use this part of the path anyway, since they are separated by buckets already.
I will check as part of this work that all the files are in the correct place so this code will function. DEV env seems to be the biggest culprit since we have tested the feature here the most.