### PR TITLE
Overwrite fog aws url method to get correct access keys

### DIFF
--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -32,6 +32,10 @@ class FileUploader < CarrierWave::Uploader::Base
     path.sub("tmp", "permanent")
   end
 
+  def url
+    Aws::S3::Presigner.new.presigned_request(:get_object, bucket: fog_directory, key: store_path).first
+  end
+
   private
 
   def clean?

--- a/app/uploaders/form_answer_pdf_version_uploader.rb
+++ b/app/uploaders/form_answer_pdf_version_uploader.rb
@@ -14,6 +14,10 @@ class FormAnswerPdfVersionUploader < CarrierWave::Uploader::Base
     end
   end
 
+  def url
+    Aws::S3::Presigner.new.presigned_request(:get_object, bucket: fog_directory, key: store_path).first
+  end
+
   def permanent_storage
     @permanent_storage ||= CarrierWave::Storage::Fog.new(self)
   end

--- a/spec/controllers/audit_certificate_context_concern_spec.rb
+++ b/spec/controllers/audit_certificate_context_concern_spec.rb
@@ -14,6 +14,9 @@ describe AuditCertificateContext, type: :controller do
     routes.draw {
       get "show" => "anonymous#show"
     }
+    double = instance_double("Aws::S3::Presigner")
+    allow(Aws::S3::Presigner).to receive(:new).and_return(double)
+    allow(double).to receive(:presigned_request).and_return ["https://bucket.s3.eu-west-2.amazonaws.com/presigned-url"]
   end
 
   describe "GET show" do
@@ -25,7 +28,7 @@ describe AuditCertificateContext, type: :controller do
       allow(FormAnswer).to receive(:find) { form_answer }
       allow_any_instance_of(FormAnswer).to receive(:audit_certificate).and_return(audit_certificate)
       get :show, params: { form_answer_id: form_answer.id }
-      expect(response).to redirect_to audit_certificate.attachment_url
+      expect(response).to redirect_to "https://bucket.s3.eu-west-2.amazonaws.com/presigned-url"
     end
   end
 end

--- a/spec/controllers/form_controller_spec.rb
+++ b/spec/controllers/form_controller_spec.rb
@@ -126,6 +126,12 @@ describe FormController do
   describe "#add_attachment" do
     let(:file) { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/cat.jpg"), "image/jpeg") }
 
+    before do
+      double = instance_double("Aws::S3::Presigner")
+      allow(Aws::S3::Presigner).to receive(:new).and_return(double)
+      allow(double).to receive(:presigned_request).and_return ["https://bucket.s3.eu-west-2.amazonaws.com/presigned-url"]
+    end
+
     it "adds attachment to the form answer" do
       expect {
         post :add_attachment, params: {

--- a/spec/features/users/figures_and_vat_returns_spec.rb
+++ b/spec/features/users/figures_and_vat_returns_spec.rb
@@ -16,6 +16,9 @@ describe "User uploads VAT returns and actual figures" do
       kind: "shortlisted_notifier",
       trigger_at: DateTime.now - 1.day,
     )
+    double = instance_double("Aws::S3::Presigner")
+    allow(Aws::S3::Presigner).to receive(:new).and_return(double)
+    allow(double).to receive(:presigned_request).and_return ["https://bucket.s3.eu-west-2.amazonaws.com/presigned-url"]
   end
 
   it "allows to submit vat returns and actual figures" do


### PR DESCRIPTION
Because of our slightly weird fog/carrierwave setup, the presigned URLs were broken when we switched AV. Use the Aws::S3 lib to get the correct creds in the URL.

This requires the keys
AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY

to be present in the env (they are different from the tmp/clean bucket creds)