### PR TITLE
fix: prevent sign-in after password reset request

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,3 +1,35 @@
 class Users::PasswordsController < Devise::PasswordsController
   include Users::ReasonablyParanoidable
+
+  # Override the create method to customize the redirect after password reset request
+  def create
+    # Force sign out any current user
+    sign_out(current_user) if user_signed_in?
+
+    # Ensure Warden doesn't try to auto-authenticate
+    request.env["warden"].logout
+
+    self.resource = resource_class.send_reset_password_instructions(resource_params)
+    yield resource if block_given?
+
+    if successfully_sent?(resource)
+      # Instead of using respond_with, use a direct redirect
+      flash[:notice] = I18n.t("devise.passwords.send_paranoid_instructions")
+
+      # Clear EVERYTHING from session that could be related to authentication
+      session.delete("warden.user.user.key")
+      session.delete("devise.user_sessions")
+      session.delete("user_return_to")
+      request.env["devise.skip_storage"] = true
+      request.env["devise.skip_trackable"] = true
+
+      # Set a session flag to indicate this is coming from a password reset
+      session[:from_password_reset] = true
+
+      # Redirect to sign in page
+      redirect_to new_user_session_path(from_password_reset: true)
+    else
+      respond_with(resource)
+    end
+  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,38 @@
 class Users::SessionsController < Devise::SessionsController
+  # Before any authentication, check if we're coming from a password reset
+  prepend_before_action :check_password_reset, only: [:new, :create]
+
   def create
+    # Only attempt authentication if not from password reset
+    if session[:from_password_reset]
+      # If from password reset, show the login form without attempting authentication
+      session.delete(:from_password_reset)
+      flash[:notice] = I18n.t("devise.passwords.send_paranoid_instructions")
+      redirect_to new_user_session_path
+    else
+      super
+      flash.discard(:notice)
+    end
+  end
+
+  def new
+    # If we're coming directly from a password reset page
+    if session[:from_password_reset]
+      # Update flash message but don't clear the flag yet (will be cleared in create)
+      flash[:notice] = I18n.t("devise.passwords.send_paranoid_instructions")
+    end
+
     super
-    flash.discard(:notice)
+  end
+
+  private
+
+  def check_password_reset
+    # Check referrer for password resets
+    if request.referer&.include?("passwords") || params[:from_password_reset]
+      session[:from_password_reset] = true
+      # Force sign out if there's any existing session
+      sign_out(current_user) if user_signed_in?
+    end
   end
 end

--- a/config/initializers/devise_reset_password_fix.rb
+++ b/config/initializers/devise_reset_password_fix.rb
@@ -1,0 +1,21 @@
+# This initializer overrides Devise's automatic sign-in behavior after password reset
+module Devise
+  module Controllers
+    module Helpers
+      # Override the original sign_in method to check for password reset context
+      alias_method :original_sign_in, :sign_in
+
+      def sign_in(resource_or_scope, *args)
+        scope = Devise::Mapping.find_scope!(resource_or_scope)
+
+        # Don't automatically sign in if this is a password reset session for users
+        if session[:from_password_reset] && scope.to_s == "user"
+          Rails.logger.info "Prevented auto sign-in after password reset for user"
+          return false
+        end
+
+        original_sign_in(resource_or_scope, *args)
+      end
+    end
+  end
+end


### PR DESCRIPTION
There was confusing behaviour happening - after a user requested a password reset they were being redirected to the login page and an alert said that the email or password was invalid. This was confusing as it looks like they had entered the wrong email - however the application was redirecting back to login page and then trying to login automatically.

This fix overrides devise controllers to redirect to login but not auto-login and a new alert is shown.

<img width="1137" alt="Screenshot 2025-04-14 at 09 32 44" src="https://github.com/user-attachments/assets/6e9c861c-6abb-414b-9ff8-12a5b3965fb6" />
