### PR TITLE
fix: updates banner logic

### DIFF
--- a/app/views/content_only/dashboard.html.slim
+++ b/app/views/content_only/dashboard.html.slim
@@ -2,14 +2,15 @@
 
 - provide(:page_wrapper_class, "page-dashboard")
 
-- if Settings.winners_stage?
-  = render "content_only/info_messages/award_season_closed"
-- elsif Settings.after_shortlisting_stage?
-  = render "content_only/info_messages/award_season_shortlisting"
-- elsif submission_started? && !submission_ended?
+- if submission_started? && !submission_ended?
   = render "content_only/info_messages/award_season_open"
-- elsif Settings.current_award_year_switched?
-  = render "content_only/info_messages/award_season_closed"
+- else
+  - if Settings.winners_stage?
+    = render "content_only/info_messages/award_season_closed"
+  - elsif Settings.after_shortlisting_stage?
+    = render "content_only/info_messages/award_season_shortlisting"
+  - else Settings.current_award_year_switched?
+    = render "content_only/info_messages/award_season_closed"
 
 - if Settings.after_current_submission_deadline_start? || past_applications.present?
   h1.govuk-heading-xl


### PR DESCRIPTION
During testing on dev and staging environments the banners weren't displaying as expected. In the unlikely event that the winners_mailer had been sent but the awards season was opened, the closed banner was shown. The logic is therefore changed to show the awards_open banner if the awards are open and submission not closed.

Another issue was found where the award year opening was not set and the award year had switched due to falling back on defaults. In this case no banner was showing so the logic is updated to show the closed banner as the final condition.

The new logic is therefore:
- check for submission started and not ended
  show award season open banner
- otherwise if winners mailer is sent
  show closed banner
- otherwise if shortlisted mailer is sent
  show shortlisted banner
 - else
   show closed banner
   
 Because the winners mailer is sent after shortlisted this should be the first check.